### PR TITLE
Update faraday version

### DIFF
--- a/linkedin-oauth2.gemspec
+++ b/linkedin-oauth2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "oauth2",  "~> 1.0"
   gem.add_dependency "hashie",  "~> 3.2"
-  gem.add_dependency "faraday", "~> 0.9"
+  gem.add_dependency "faraday", "~> 0.12"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Does not have breaking change apart from inability to use Ruby version < 1.8.

Enables use of gem we need.